### PR TITLE
main needs a return type designated and a return statement added.

### DIFF
--- a/iozone/create_file.c
+++ b/iozone/create_file.c
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <stdlib.h>
 
+int
 main(int argc, char **argv)
 {
 	char *buffer;
@@ -20,4 +21,5 @@ main(int argc, char **argv)
 		fwrite(buffer, 1024*1024, 1, fd);
 	}
 	fclose(fd);
+	return(0);
 }


### PR DESCRIPTION
Fix build warnings
reate_file.c:5:1: error: return type defaults to 'int' [-Wimplicit-int]
    5 | main(int argc, char **argv)
      | ^~~~

Need to be 
int
main(...)
{
....
return(0);
}