### PR TITLE
Adding mmapincache to the list of recognized command line options

### DIFF
--- a/iozone/iozone_run.sh
+++ b/iozone/iozone_run.sh
@@ -1374,6 +1374,7 @@ NO_ARGUMENTS=(
 	"incache"
 	"iozone_umount"
 	"lvm_disk"
+ 	"mmapincache"
 	"outofcache"
 	"swap"
 	"syncedincache"


### PR DESCRIPTION
Description:
This adds mmapincache to the list of recognized "no argument" command line options. The functionality was already there and worked with --all_test, but the option needs to be enabled to run the subtest independently.

Before: 
iozone_run.sh: unrecognized option '--mmapincache'

After:
No errors running with the option

This closes #24 
Relates to JIRA: RPOPC-294