### PR TITLE
Results filename cleanup + typo fixes

### DIFF
--- a/iozone/iozone_run.sh
+++ b/iozone/iozone_run.sh
@@ -170,9 +170,6 @@ tools_git=https://github.com/redhat-performance/test_tools-wrappers
 #
 # Config info
 #
-disk_type=""
-disk_size=""
-disk_numb=""
 
 #
 # Help message
@@ -596,8 +593,8 @@ do_test_actual()
 
 	for one_run in $run_types; do
 		runtest_fq_name=${runtest_name}"_"${one_run}
-		iozone_output_file=${analysis_dir}/${fstype}/iozone_${test_prefix}_${runtest_fq_name}_dt_${disk_type}_ds_${disk_size}_dn_${disk_numb}.iozone
-		iozone_analysis_file=${analysis_dir}/${fstype}/iozone_${runtest_fq_name}_dt_${disk_type}_ds_${disk_size}_dn_${disk_numb}_analysis+rawdata.log
+		iozone_output_file=${analysis_dir}/${fstype}/iozone_${test_prefix}_${runtest_fq_name}.iozone
+		iozone_analysis_file=${analysis_dir}/${fstype}/iozone_${runtest_fq_name}_analysis+rawdata.log
 		if [[ -d "${mount_location}" && ${do_iozone_umount} == 1 ]]; then
 			export iozone_args="-U ${data_mnt_pt} ${iozone_args}"
 		fi
@@ -1539,9 +1536,6 @@ while [[ $# -gt 0 ]]; do
 	esac
 	shift;
 done
-disk_type=`echo $to_configuration | cut -d'_' -f2 | cut -d'=' -f2`
-disk_size=`echo $to_configuration | cut -d'=' -f3 | cut -d'_' -f 1`
-disk_numb=`echo $to_configuration | cut -d'=' -f4 | cut -d'_' -f 1`
 
 if [ `id -u` -ne 0 ]; then
 	exit_out "You need to run as root" 1

--- a/iozone/iozone_run.sh
+++ b/iozone/iozone_run.sh
@@ -179,8 +179,7 @@ usage()
 	echo "Wrapper specific options"
 	echo "======================================================================"
 	echo "all_test: executes all the predefined tests, which currently are"
-	echo "    incache, incache_fsync, incache_mmap, incache_fsync, incache_mmap"
- 	echo "    out_of_cach dio."
+	echo "    incache, incache_fsync, incache_mmap, out_of_cache dio"
 	echo "devices_to_use <dev_a, dev_b>: comma separate list of devices to create"
 	echo "   the filesystem on. Default none."
 	echo "dio_filelimit <MB>: maximun size the file may be when doing directio."
@@ -212,7 +211,7 @@ usage()
 	echo "results_dir <dir>:  Where to place the results from the run.  The default"
 	echo "   is the <current directory>/results"
 	echo "swap: Turn off swap during testing, and reenable it when done."
-	echo "syncedincache: Run the test incache with fsync"
+	echo "syncedincache: Run the test in cache with fsync"
 	echo "test_prefix <string>:  Prefix to add to the results file."
 	echo "   Default is test_run"
 	echo "tools_git: Pointer to the test_tools git.  Default is ${tools_git}.  Top directory is always test_tools"
@@ -825,7 +824,7 @@ set_mem_vals()
 	fi
 
 	#
-	# Cap direct I/O.  Use in cache limit as a guide.  we can change this latera.
+	# Cap direct I/O.  Use in cache limit as a guide.  we can change this later.
 	#
 
 	if [ ${incache_memory} -gt ${dio_filelimit} ]; then


### PR DESCRIPTION
Description:

This PR removes the calculation of disk type, size, and number for inclusion in the filename for raw results. The calculation depends on configuration information which isn't being passed to the wrapper and which for some configurations won't provide useful information (e.g: "RAID" doesn't tell me anything about the RAID disks being used). Removing these calculated fields make the results filenames look like those generated by our previous internal wrapper. If we later want the disk information included it should probably go in results file metadata but for now this makes the filenames cleaner.

Also, a few typos are fixed.

Before:
Filename is something like iozone_incache_default_dt_really.long.fqdn.of.test.system_ds_really.long.fqdn.of.test.system_dn_really.long.fqdn.of.test.system.iozone

After:
Filename is something like iozone_test_run_incache_default.iozone

Clerical:

This closes #22 
Relates to JIRA: RPOPC-302