### PR TITLE
Filesystem selection fix

### DIFF
--- a/iozone/iozone_run.sh
+++ b/iozone/iozone_run.sh
@@ -1053,7 +1053,7 @@ invoke_test()
 				
 			echo ""
 
-			if [ -f "${local_watchdog_file}" ];then
+			if [[ -f "${local_watchdog_file}" ]];then
 				break;
 			fi
 		done

--- a/iozone/iozone_run.sh
+++ b/iozone/iozone_run.sh
@@ -243,7 +243,7 @@ usage()
 	echo "Total file size:  Default of 10G"
 	echo "${exec_file} --incache --results_dir `pwd`/testing --test_type 0,1"
 	echo "   --mount_location /iozone/iozone0 --devices_to_use /dev/nvme3n1"
-	echo "   --filesys xfs --file_count_list 1,2,4 --auto"
+	echo "   --filesystems xfs --file_count_list 1,2,4 --auto"
 	echo ""
 	echo "Test: incache, using iozone tests 0 through 12"
 	echo "results: current directory/testing."
@@ -254,7 +254,7 @@ usage()
 	echo "Total file size:  Default of 64G"
 	echo "Disk to use: /dev/nvme3n1 and /dev/nvme2n1"
 	echo "${exec_file} --incache --results_dir `pwd`/dave --mount_location /iozone/iozone"
-	echo "   --devices_to_use /dev/nvme3n1,/dev/nvme2n1 --filesys xfs --file_count_list 1,2"
+	echo "   --devices_to_use /dev/nvme3n1,/dev/nvme2n1 --filesystems xfs --file_count_list 1,2"
 	echo "   --test_prefix io_test_all --max_file_size 64"
 	echo "   --test_type 0,1,2,3,4,5,6,7,8,9,10,11,12"
 	source test_tools/general_setup --usage


### PR DESCRIPTION
# Description
This PR resolves the problem of all runs getting tagged as XFS regardless of which filesystem is actually being used. The problem comes from a bad interaction between two loops (one inside the other) which both try to validate filesystems and mount points and consequently confuse the logging process.

The function which creates the bad interaction is removed.
Variables are updated to accommodate the removal of said function
Usage information related to filesystem selection is corrected
An unrelated typo is fixed

# Before/After Comparison
Before the fix all runs appear to run under xfs even if they don't.
After the fix, results are placed in the proper directories and include the correct filesystem. Verified by watching the mount points and logging change during a multi-filesystem run

# Clerical Stuff
This closes #34 
Relates to JIRA: RPOPC-357
