### PR TITLE
Enable directio

### DIFF
--- a/iozone/iozone_run.sh
+++ b/iozone/iozone_run.sh
@@ -1052,7 +1052,6 @@ execute_iozone()
                         test_specific_args="-I -n ${page_size}k -g ${dio_maxfile}m -y 64k -q 1m -i 0 -i 1 -i 2 -i 3 -i 4 -i 5"
                         do_test "Direct_IO" "directio" ${test_specific_args}
                 fi
-  
         else
                 if [[ ${do_incache} -eq 1 ]]; then
                         test_specific_args=""   #intentionally left empty, everybody gets one
@@ -1064,14 +1063,14 @@ execute_iozone()
                         do_test "In_Cache_+_Fsync" "incache+fsync" ${test_specific_args}
                 fi
 
-		if [[ ${do_dio} -eq 1 ]]; then
-                        test_specific_args="-I -i 0 -i 1 -i 2 -i 3 -i 4 -i 5"
-                        do_test "Direct_IO" "directio" ${test_specific_args}
-                fi
-
                 if [[ ${do_incache_mmap} -eq 1 ]]; then
                         test_specific_args=" -B"
                         do_test "In_Cache_w_MMAP" "incache+mmap" ${test_specific_args}
+                fi
+
+		if [[ ${do_dio} -eq 1 ]]; then
+                        test_specific_args="-I -i 0 -i 1 -i 2 -i 3 -i 4 -i 5"
+                        do_test "Direct_IO" "directio" ${test_specific_args}
                 fi
         fi
 

--- a/iozone/iozone_run.sh
+++ b/iozone/iozone_run.sh
@@ -1047,6 +1047,12 @@ execute_iozone()
                         test_specific_args=" -n ${page_size}k -g ${incache_maxfile}m -y 1k -q 1m -B"
                         do_test "In_Cache_w_MMAP" "incache+mmap" ${test_specific_args}
                 fi
+
+		if [[ ${do_dio} -eq 1 ]]; then 
+                        test_specific_args="-I -n ${page_size}k -g ${dio_maxfile}m -y 64k -q 1m -i 0 -i 1 -i 2 -i 3 -i 4 -i 5"
+                        do_test "Direct_IO" "directio" ${test_specific_args}
+                fi
+  
         else
                 if [[ ${do_incache} -eq 1 ]]; then
                         test_specific_args=""   #intentionally left empty, everybody gets one
@@ -1056,6 +1062,11 @@ execute_iozone()
                 if [[ ${do_incache_fsync} -eq 1 ]]; then
                         test_specific_args=" -e"
                         do_test "In_Cache_+_Fsync" "incache+fsync" ${test_specific_args}
+                fi
+
+		if [[ ${do_dio} -eq 1 ]]; then
+                        test_specific_args="-I -i 0 -i 1 -i 2 -i 3 -i 4 -i 5"
+                        do_test "Direct_IO" "directio" ${test_specific_args}
                 fi
 
                 if [[ ${do_incache_mmap} -eq 1 ]]; then


### PR DESCRIPTION
# Description
This PR enables use of directio  in automatic and throughput modes. It was prepped in a "to do" section but never moved into the "live" code. For automatic mode, this gives the wrapper the same directio functionality as the legacy Beakerized version.

# Before/After Comparison
Before: The --directio flag was ignored
After: The --directio flag makes the wrapper run the directio test case. 

# Clerical Stuff
This closes #35 
Relates to JIRA: RPOPC-358
