### PR TITLE
Enable out_of_cache for auto mode

### DIFF
--- a/iozone/iozone_run.sh
+++ b/iozone/iozone_run.sh
@@ -979,7 +979,7 @@ execute_iozone()
                         if [[ ${do_eat_mem} == 1 ]];then
                                ${eatmem_exe} ${memory_to_take} &
                                PID=$!
-                               sleep 180
+                               sleep 180	# This is okay for now, but we're going to want to reevaluate at some point.
                                sync
                                echo 3 > /proc/sys/vm/drop_caches
                                sleep 10


### PR DESCRIPTION
# Description
This change enables the "Out of Cache" option for automatic mode. The enabling code was included with the original port from the legacy Barry/Tommy version but was inactive pending testing (it was in the "fix this later" area). This brings the data collection ability of iozone-wrapper to parity with the legacy version; automatic mode now supports all of the previously existing incache/outofcache/directio/fsync/mmap options.

# Before/After Comparison
Before: if --outofcache is used then the outofcache test won't happen because the code is unreachable
After: if --outofcache is used the outofcache test will happen

# Clerical Stuff
This is a partial fix for #36 . This handles iozone's auto mode; throughput mode still needs rework.
Relates to JIRA: RPOPC-359
