### PR TITLE
Throughput mode rework

### DIFF
--- a/iozone/iozone_run.sh
+++ b/iozone/iozone_run.sh
@@ -1208,7 +1208,7 @@ reduce_non_auto_data()
 	# The averaging script wasn't meant for throughput mode
 	resdir="Run_1"
 	# Add the column headers
-	echo filesys:op:${file_count_list} | sed 's/ /proc:/g; s/$/proc/' >> /tmp/results.csv
+	echo filesys:mode:op:${file_count_list} | sed 's/ /proc:/g; s/$/proc/' >> /tmp/results.csv
 
         pushd ${results_dir}/${resdir} >& /dev/null
         for resfs in $filesystems


### PR DESCRIPTION
# Description
This reworks the use of iozone's throughput mode by:
--enabling spreadsheet-friendly output
--reworking the assembly of the iozone command line to facilitate the use of spreadsheet mode
--replacing the data reduction methodology for throughput mode to handle spreadsheet-friendly output and eliminate the problem of not handling multiple iterations in one run (only the most recent run is preserved)
--Makes the final CSV file more post-processing friendly
 
# Before/After Comparison
Before:
Only the most recent filesystem/testmode run is preserved, and only certain subtests are handled correctly (and those by brute force)
CSV file isn't post-processing friendly
Ex: 
<metadata snipped>
processes:test_type:file_sze:record_size:Total_througput
1:initial writers:10485760 kB:Record Size 1024 kB: 1186870.25 kB/sec
1:readers:10485760 kB:Record Size 1024 kB: 3683637.25 kB/sec
2:initial writers:5242880 kB:Record Size 1024 kB: 1200949.69 kB/sec
2:readers:5242880 kB:Record Size 1024 kB: 3711953.50 kB/sec
4:initial writers:2097152 kB:Record Size 1024 kB: 1211215.00 kB/sec
4:readers:2097152 kB:Record Size 1024 kB: 3724389.06 kB/sec

After:
Spreadsheet-friendlyoutput is enabled
All run results are processed into a consolidated CSV
CSV file is post-processing friendly
Ex:
<metadata snipped>
filesys:mode:op:1proc:2proc:4proc
xfs:incache:Initialwrite:13009629.00:12969813.50:12874782.50
xfs:incache:Rewrite:13283659.00:13076599.50:13061553.50
xfs:incache:Read:10675931.00:10447949.00:10391854.00
xfs:incache:Re-read:10757681.00:10449202.00:10254559.75


# Clerical Stuff
This closes #28 
Relates to JIRA: RPOPC-296
