### PR TITLE
Add wget to json

### DIFF
--- a/iozone/iozone-wrapper.json
+++ b/iozone/iozone-wrapper.json
@@ -10,10 +10,7 @@
       "perl-Math-BigRat",
       "unzip",
       "wget",
-      "zip",
-      "pcp-zeroconf",
-      "pcp-pmda-openmetrics",
-      "pcp-pmda-denki"
+      "zip"
     ],
     "ubuntu": [
       "bc",
@@ -23,8 +20,7 @@
       "linux-tools-generic",
       "libmath-bigint-perl",
       "unzip",
-      "zip",
-      "pcp-zeroconf"
+      "zip"
     ]
   }
 }


### PR DESCRIPTION
# Description
This adds wget to the list of dependencies which need to be installed. It's "free" in RHEL 10 but not in RHEL 9
This also removes the pcp packages from the list. They're handled by the pcp code in test_tools, but I deemed it simpler to leave them (due to idempotency) until there was a compelling reason to mess with the iozone files.

# Before/After Comparison
Before: The iozone wrapper can't wget the iozone tarball
After: The iozone wrapper can wget the iozone tarball

# Clerical Stuff
This closes #53 
Relates to JIRA: RPOPC-754
