### PR TITLE
Bumping default iozone version to 508

### DIFF
--- a/iozone/iozone_run.sh
+++ b/iozone/iozone_run.sh
@@ -131,7 +131,7 @@ buildrunlog=${results_dir}/build-run.log
 arch=`arch | sed 's/i686/i386/'`
 
 testing_dir=`pwd`
-iozone_kit=iozone3_490
+iozone_kit=iozone3_508
 
 do_incache=0
 do_incache_fsync=0


### PR DESCRIPTION
# Description
This bumps the default version of IOzone installed by the wrapper from 3.490 (dated and not marked "stable" upstream) to 3.508 (current stable release).  There are no changes to wrapper logic or output or usage of iozone itself. 

# Before/After Comparison
Before: If no iozone exists on the test system the wrapper will install version 3.490.
After:  If no iozone exists on the test system the wrapper will install version 3.508

# Clerical Stuff
This closes #60 
Relates to JIRA: RPOPC-920

 Logs [iozone_490_to_508.txt](https://github.com/user-attachments/files/27571369/iozone_490_to_508.txt)

